### PR TITLE
Support StartupThreshold for probes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,7 @@ type Probe struct {
 	// TCPSocket interface{} `yaml:"tcpSocket`
 
 	FailureThreshold    int `yaml:"failureThreshold"`
+	StartupThreshold    int `yaml:"startupThreshold"`
 	InitialDelaySeconds int `yaml:"initialDelaySeconds"`
 	PeriodSeconds       int `yaml:"periodSeconds"`
 	TimeoutSeconds      int `yaml:"timeoutSeconds"`
@@ -72,6 +73,9 @@ func (p *Probe) validate() error {
 	}
 	if p.FailureThreshold < 1 {
 		return errors.New("Probe failureThreshold needs to be at least 1")
+	}
+	if p.StartupThreshold < 0 {
+		return errors.New("Probe startupThreshold need to be positive")
 	}
 	if p.InitialDelaySeconds < 0 {
 		return errors.New("Probe initialDelaySeconds need to be positive")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,6 +16,7 @@ probes:
       command:
         - true
     failureThreshold: 5
+    startupThreshold: 10
     initialDelaySeconds: 3
     periodSeconds: 4
     timeoutSeconds: 6
@@ -23,6 +24,7 @@ probes:
       command:
         - true
     failureThreshold: 5
+    startupThreshold: 10
     initialDelaySeconds: 3
     periodSeconds: 4
     timeoutSeconds: 6
@@ -41,6 +43,7 @@ probes:
 		assert.NotNil(t, probe.Exec)
 		assert.Equal(t, []string{"true"}, probe.Exec.Command)
 		assert.Equal(t, 5, probe.FailureThreshold)
+		assert.Equal(t, 10, probe.StartupThreshold)
 		assert.Equal(t, 3, probe.InitialDelaySeconds)
 		assert.Equal(t, 4, probe.PeriodSeconds)
 		assert.Equal(t, 6, probe.TimeoutSeconds)
@@ -70,6 +73,7 @@ probes:
 		assert.NotNil(t, probe.Exec)
 		assert.Equal(t, []string{"true"}, probe.Exec.Command)
 		assert.Equal(t, 3, probe.FailureThreshold)
+		assert.Equal(t, 0, probe.StartupThreshold)
 		assert.Equal(t, 0, probe.InitialDelaySeconds)
 		assert.Equal(t, 10, probe.PeriodSeconds)
 		assert.Equal(t, 1, probe.TimeoutSeconds)

--- a/pkg/prober/prober.go
+++ b/pkg/prober/prober.go
@@ -54,6 +54,8 @@ func (p *prober) Run(ctx context.Context) error {
 		time.Sleep(time.Duration(p.config.InitialDelaySeconds) * time.Second)
 	}
 
+	startup := p.config.StartupThreshold > 0
+
 	periodDuration := time.Duration(p.config.PeriodSeconds) * time.Second
 	failureCount := 0
 	for {
@@ -62,9 +64,15 @@ func (p *prober) Run(ctx context.Context) error {
 			failureCount++
 		} else {
 			failureCount = 0
+			startup = false
 		}
 
-		if failureCount >= p.config.FailureThreshold {
+		threshold := p.config.FailureThreshold
+		if startup {
+			threshold = p.config.StartupThreshold
+		}
+
+		if failureCount >= threshold {
 			return err
 		}
 


### PR DESCRIPTION
Similar to k8s StartupProbes, this makes it possible to configure the
initial treshold until the probe succeeds once.